### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - main
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install build
+        run: |
+          python -m pip install -U pip
+          pip install build
+      - name: Build distribution
+        run: python -m build
+      - name: Sign artifacts
+        if: secrets.GPG_PRIVATE_KEY != ''
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --yes --import
+          for file in dist/*; do
+            gpg --batch --yes --armor --detach-sign "$file"
+          done
+      - name: Publish to TestPyPI
+        if: contains(github.ref, '-rc') || contains(github.ref, '-beta')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TESTPYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish to PyPI
+        if: "!contains(github.ref, '-rc') && !contains(github.ref, '-beta')"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- allow `ci.yml` to be called from other workflows
- add `publish.yml` for releasing to PyPI/TestPyPI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dff4613a483279ca10e95b5868cbb