### PR TITLE
Add MkDocs site and docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install mkdocs-material python-markdown-math mkdocs-awesome-pages-plugin mkdocs-check-links
+      - name: Deploy Docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          mkdocs gh-deploy --force --strict --remote-branch gh-pages

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome to Synergy-Coherence-Lab Docs
+
+This site contains the project documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: Synergy-Coherence-Lab Docs
+nav:
+  - Home: index.md
+theme:
+  name: material
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.tabbed
+  - md_in_html
+  - admonition
+  - codehilite
+  - toc
+  - tables
+  - footnotes
+  - sane_lists
+  - pymdownx.arithmatex
+plugins:
+  - search
+  - awesome-pages
+  - check-links
+repo_url: https://github.com/AcashaOrg/synergy-coherence-lab


### PR DESCRIPTION
## Summary
- set up MkDocs configuration using Material theme with link checking
- add placeholder documentation index
- deploy docs to `gh-pages` on push to `main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e011de69483279aa5ee56e26d2374