### PR TITLE
Add Makefile for linting, testing and releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: lint test nb ci release
+
+lint:
+	ruff check .
+
+test:
+	pytest -q
+
+nb:
+	jupyter nbconvert --to notebook --execute notebooks/*.ipynb \
+		--output-dir executed_notebooks \
+		--ExecutePreprocessor.timeout=0
+
+ci: lint test nb
+
+release:
+ifndef VERSION
+	$(error VERSION is not set)
+endif
+	git tag -a v$(VERSION) -m "v$(VERSION)"
+	git push origin v$(VERSION)
+	python -m build
+	twine upload dist/*


### PR DESCRIPTION
## Summary
- add a Makefile with tasks for linting, testing, notebooks, CI and release

## Testing
- `ruff check .` *(fails: F401 in notebook)*
- `pytest -q`
- `make nb` *(fails: `jupyter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e027d135883278adaa4788ba40aa4