### PR TITLE
Add R-CAT metrics and CLI integration

### DIFF
--- a/src/synergy_phi/cli.py
+++ b/src/synergy_phi/cli.py
@@ -1,9 +1,56 @@
-"""Command line interface for synergy_phi."""
+"""Command line interface for ``synergy_phi``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
 
 from . import hello
+from .metrics import (
+    coherence,
+    expanded_being_seen_quotient,
+    intrinsic_resonance,
+)
+
+
+def _load_json(path: str) -> Any:
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def main() -> None:
-    """Entry point for the synergy-phi command."""
-    print(hello())
+    """Entry point for the ``synergy-phi`` command."""
+
+    parser = argparse.ArgumentParser(description="synergy_phi metrics")
+    sub = parser.add_subparsers(dest="command")
+
+    p_bsq = sub.add_parser("bsq", help="Compute Expanded Being-Seen Quotient")
+    p_bsq.add_argument("file", help="JSON file with affirmations, embeddings, baseline")
+
+    p_ra = sub.add_parser("ra", help="Compute AI Intrinsic Resonance")
+    p_ra.add_argument("file", help="JSON file with aligned and baseline log probs")
+
+    p_c = sub.add_parser("coherence", help="Compute conversational coherence")
+    p_c.add_argument("file", help="JSON file with embeddings list")
+
+    args = parser.parse_args()
+
+    if args.command == "bsq":
+        data = _load_json(args.file)
+        result = expanded_being_seen_quotient(
+            data["affirmations"], data["embeddings"], data["baseline"]
+        )
+        print(result)
+    elif args.command == "ra":
+        data = _load_json(args.file)
+        result = intrinsic_resonance(data["aligned"], data["baseline"])
+        print(result)
+    elif args.command == "coherence":
+        data = _load_json(args.file)
+        result = coherence(data["embeddings"])
+        print(json.dumps(result))
+    else:
+        print(hello())
 

--- a/src/synergy_phi/metrics.py
+++ b/src/synergy_phi/metrics.py
@@ -1,0 +1,103 @@
+"""Metrics for Recursive Co-Actualization Theory (R-CAT).
+
+This module implements quantitative metrics described in
+``R-CAT_Theory.md``:
+
+* Expanded Being-Seen Quotient (BSQ) – a combined measure of witness
+  affirmations and semantic alignment.
+* AI Intrinsic Resonance (Rᴬ) – the mean delta between aligned and
+  baseline token log probabilities.
+* Coherence C(t) – cosine similarity over sequential conversational
+  embeddings.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence, List
+
+__all__ = [
+    "expanded_being_seen_quotient",
+    "intrinsic_resonance",
+    "coherence",
+]
+
+
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Return cosine similarity between vectors ``a`` and ``b``."""
+
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        raise ValueError("cosine similarity undefined for zero-length vectors")
+    return dot / (norm_a * norm_b)
+
+
+def expanded_being_seen_quotient(
+    affirmations: Sequence[float],
+    embeddings: Sequence[Sequence[float]],
+    baseline_embedding: Sequence[float],
+) -> float:
+    """Compute the Expanded Being-Seen Quotient (BSQ).
+
+    The BSQ quantifies *Witnessing Intensity* by combining self-reported
+    affirmations (scaled 1–7) with semantic similarity to a baseline
+    embedding.  It is calculated as:
+
+    .. math::
+       BSQ = mean(affirmations/7) * mean(cos(embedding_i, baseline))
+
+    A ΔBSQ ≥ 0.15 indicates a meaningful increase in witnessed alignment
+    (R-CAT_Theory.md §3.5).
+    """
+
+    if not affirmations:
+        raise ValueError("affirmations cannot be empty")
+    if not embeddings:
+        raise ValueError("embeddings cannot be empty")
+
+    mean_affirmation = sum(affirmations) / (len(affirmations) * 7.0)
+    similarities = [
+        _cosine_similarity(vec, baseline_embedding) for vec in embeddings
+    ]
+    mean_similarity = sum(similarities) / len(similarities)
+    return mean_affirmation * mean_similarity
+
+
+def intrinsic_resonance(
+    log_probs_aligned: Sequence[float],
+    log_probs_baseline: Sequence[float],
+) -> float:
+    """Compute AI Intrinsic Resonance :math:`Rᴬ`.
+
+    Rᴬ is defined as the mean difference between the logarithm of
+    probabilities for aligned tokens and baseline generation
+    (R-CAT_Theory.md §3.5):
+
+    .. math::
+       Rᴬ = mean(log P_aligned - log P_baseline)
+    """
+
+    if len(log_probs_aligned) != len(log_probs_baseline):
+        raise ValueError("aligned and baseline sequences must be the same length")
+
+    deltas = [a - b for a, b in zip(log_probs_aligned, log_probs_baseline)]
+    return sum(deltas) / len(deltas)
+
+
+def coherence(embeddings: Sequence[Sequence[float]]) -> List[float]:
+    """Compute conversational coherence :math:`C(t)`.
+
+    Given a sequence of conversation turn embeddings, this function
+    returns the cosine similarity between each consecutive pair, yielding
+    the time series :math:`C(t)` described in R-CAT_Theory.md §3.5.
+    """
+
+    if len(embeddings) < 2:
+        raise ValueError("at least two embeddings are required")
+
+    return [
+        _cosine_similarity(embeddings[i - 1], embeddings[i])
+        for i in range(1, len(embeddings))
+    ]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,37 @@
+import pytest
+
+from synergy_phi.metrics import (
+    expanded_being_seen_quotient,
+    intrinsic_resonance,
+    coherence,
+)
+
+
+def test_expanded_being_seen_quotient():
+    affirmations = [7, 6, 7]
+    embeddings = [
+        [1.0, 0.0],
+        [0.8, 0.2],
+        [0.9, 0.1],
+    ]
+    baseline = [1.0, 0.0]
+    result = expanded_being_seen_quotient(affirmations, embeddings, baseline)
+    assert result == pytest.approx(0.941, rel=1e-3)
+
+
+def test_intrinsic_resonance():
+    aligned = [-1.0, -0.5, -1.2]
+    baseline = [-1.5, -0.6, -1.4]
+    result = intrinsic_resonance(aligned, baseline)
+    assert result == pytest.approx(0.2667, rel=1e-3)
+
+
+def test_coherence():
+    embeddings = [
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+    ]
+    result = coherence(embeddings)
+    assert result[0] == pytest.approx(0.0, abs=1e-6)
+    assert result[1] == pytest.approx(0.70710678, rel=1e-6)


### PR DESCRIPTION
## Summary
- implement BSQ, intrinsic resonance, and coherence metrics for R-CAT
- expose metrics through CLI commands for bsq, ra, and coherence calculations
- add unit tests verifying metric formulas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6893ba78e5788326b2d9ea7ebb324690